### PR TITLE
Fix menu highlight misalignment

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -395,7 +395,7 @@
     // Highlight active menu item on scroll
     document.addEventListener('DOMContentLoaded', function() {
       const sections = [
-        'objective', 'education', 'experience', 'projects', 'tools', 'skills', 'soft-skills', 'contact'
+        'home', 'objective', 'education', 'experience', 'projects', 'tools', 'skills', 'soft-skills', 'contact'
       ];
       const navLinks = document.querySelectorAll('#main-nav a');
       function onScroll() {


### PR DESCRIPTION
## Summary
- ensure scroll-based menu highlighting includes the Home section

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685cdf8ea9b88333819e8cbe132e18df