### PR TITLE
Add language switcher and responsive nav

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -528,6 +528,7 @@ body.menu-visible #main-nav {
     padding: 10px 0;
   }
 }
+
 #main-nav li, #main-nav a {
   color: var(--accent-light);
   font-weight: 700;
@@ -543,11 +544,53 @@ body.menu-visible #main-nav {
   box-sizing: border-box;
   text-align: center;
 }
+html[lang='vi'] #main-nav li,
+html[lang='vi'] #main-nav a {
+  font-size: 0.95rem;
+}
 #main-nav a:hover, #main-nav a.active {
   background: var(--accent-light);
   color: #0f0f1c;
   transform: translateY(-4px) scale(1.08);
   box-shadow: 0 4px 16px rgba(0,0,0,0.10);
+}
+
+/* Adjust navigation for medium screens */
+@media (max-width: 1100px) {
+  #nav-toggle {
+    display: block;
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    background: none;
+    border: none;
+    color: var(--text-light);
+    font-size: 1.6rem;
+    cursor: pointer;
+  }
+  #main-nav ul {
+    display: none;
+    flex-direction: column;
+    gap: 0.5em;
+    background: rgba(20,30,50,0.98);
+    padding: 10px 0;
+    width: 100vw;
+    max-width: 100vw;
+    overflow-x: auto;
+    box-sizing: border-box;
+  }
+  #main-nav.open ul {
+    display: flex;
+  }
+  #main-nav li, #main-nav a {
+    font-size: 1.1em;
+    padding: 8px 0;
+    word-break: break-word;
+    white-space: normal;
+    width: 100%;
+    box-sizing: border-box;
+    text-align: center;
+  }
 }
 
 #bg-video {

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -196,6 +196,8 @@ function setLanguage(lang) {
       el.setAttribute('placeholder', translations[lang][key]);
     }
   });
+  // Update html lang attribute for styling
+  document.documentElement.setAttribute('lang', lang);
   // Lưu ngôn ngữ vào localStorage
   localStorage.setItem('lang', lang);
 }

--- a/portfolio.html
+++ b/portfolio.html
@@ -36,6 +36,10 @@
         <li><a href="#skills" data-i18n="nav_skills">Skills</a></li>
         <li><a href="#soft-skills" data-i18n="nav_soft_skills">Soft Skills</a></li>
         <li><a href="#contact" data-i18n="nav_contact">Contact</a></li>
+        <li id="lang-switcher-menu">
+          <button class="lang-btn" data-lang="en">EN</button> |
+          <button class="lang-btn" data-lang="vi">VI</button>
+        </li>
         <li id="bg-audio-menu-btn">
           <button id="bg-audio-toggle" aria-label="Toggle background audio" style="background:none;border:none;cursor:pointer;color:#fff;font-size:1.3em;padding:4px 8px;">
             <i id="bg-audio-icon" class="fas fa-volume-mute"></i>


### PR DESCRIPTION
## Summary
- restore EN/VI language switcher menu
- make navigation responsive when screen width is below 1100px
- adjust menu font size in Vietnamese
- set HTML lang attribute for styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685ce3c20f1c833399d8284a4101b64e